### PR TITLE
ci: update test to test with both latest and lowest dependencies

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -8,28 +8,37 @@ on:
 
 jobs:
   unit:
-    name: PHPUnit unit tests - PHP ${{ matrix.php-versions }}
+    name: PHPUnit unit tests - PHP ${{ matrix.php-versions }} - ${{ matrix.dependencies }}
     strategy:
       matrix:
         operating-system: [ubuntu-latest]
         php-versions: ['8.3', '8.4']
+        dependencies: ['latest', 'lowest']
     runs-on: ${{ matrix.operating-system }}
+
     steps:
       - name: Checkout
         uses: actions/checkout@v5
 
-      - name: Setup php
+      - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
           php-version: ${{ matrix.php-versions }}
+          tools: composer:v2
+          coverage: none
 
       - name: Check PHP Version
         run: php -v
 
-      - name: Download dependencies
-        uses: php-actions/composer@v6
-        with:
-          args: --ignore-platform-reqs --quiet
+      - name: Install dependencies (latest)
+        if: matrix.dependencies == 'latest'
+        run: |
+          composer update --ignore-platform-reqs --quiet
+
+      - name: Install dependencies (lowest)
+        if: matrix.dependencies == 'lowest'
+        run: |
+          composer update --prefer-lowest --ignore-platform-reqs --quiet
 
       - name: Run PHPUnit unit tests
         run: composer test

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -8,19 +8,19 @@ on:
 
 jobs:
   unit:
-    name: PHPUnit unit tests - PHP ${{ matrix.php-versions }} - ${{ matrix.dependencies }}
+    name: PHPUnit unit tests - PHP ${{ matrix.php-versions }} - ${{ matrix.dependency-version-strategy }}
     strategy:
       matrix:
         operating-system: [ubuntu-latest]
         php-versions: ['8.3', '8.4']
-        dependencies: ['latest', 'lowest']
+        dependency-version-strategy: [ 'latest', 'lowest']
     runs-on: ${{ matrix.operating-system }}
 
     steps:
       - name: Checkout
         uses: actions/checkout@v5
 
-      - name: Setup PHP
+      - name: Setup php
         uses: shivammathur/setup-php@v2
         with:
           php-version: ${{ matrix.php-versions }}
@@ -31,12 +31,12 @@ jobs:
         run: php -v
 
       - name: Install dependencies (latest)
-        if: matrix.dependencies == 'latest'
+        if: matrix.dependency-version-strategy == 'latest'
         run: |
           composer update --ignore-platform-reqs --quiet
 
       - name: Install dependencies (lowest)
-        if: matrix.dependencies == 'lowest'
+        if: matrix.dependency-version-strategy == 'lowest'
         run: |
           composer update --prefer-lowest --ignore-platform-reqs --quiet
 


### PR DESCRIPTION
This should resolve #37, so that both latest and lowest are tested.

I have removed the composer-setup path, as it's can be done directly with setup-php.
I have also added the `coverage: none` to not include `xdebug` nor `pcov` which will slow down the tests. 

What still could be considered is composer caching, but I can look into that later if you want.